### PR TITLE
Update TUG test automatic ending detection algorithm

### DIFF
--- a/app/core/tasks/tug/recognition-result-evaluation.ts
+++ b/app/core/tasks/tug/recognition-result-evaluation.ts
@@ -5,6 +5,8 @@ import { Activity, fromString } from "~/core/tug-test/activities";
 import { getTugManager, TugManager } from "~/core/tug-test/manager";
 import { Status } from "~/core/tug-test/execution";
 
+const SIGNIFICANCE_THRESHOLD = 0.7;
+
 const DEFAULT_EVENT = "testEvaluationTaskFinished";
 const TEST_ENDING_EVENT = "detectedTugTestEnding";
 
@@ -29,22 +31,31 @@ export class RecognitionResultEvaluationTask extends Task {
     const recognitionResult = invocationEvent.data as RecognitionResult;
     currentExecution.addNew(recognitionResult);
 
-    const lastThree = currentExecution.recognitionResults
-      .slice(-3)
-      .map((recognitionResult) => fromString(recognitionResult.inference.class));
+    const lastThree = currentExecution.recognitionResults.slice(-3);
+    const activity = fromString(lastThree[0].inference.class);
 
-    if (this.areEqual(lastThree) && this.areDifferent(currentExecution.current, lastThree[0])) {
-      currentExecution.setCurrentActivity(lastThree[0]);
-    }
-
-    if (currentExecution.checkPreviousCurrentSequence(Activity.TURNING,Activity.WALKING)) {
-      currentExecution.status = Status.SECOND_PHASE;
-    }
-
+    // If the last three estimations are the same activity and
+    // that activity is different than the current one update the current activity
     if (
-      currentExecution.checkPreviousCurrentSequence(Activity.SITTING,Activity.SIT) &&
-      currentExecution.status === Status.SECOND_PHASE
+      areRecognitionsEqualAndSignificant(lastThree) &&
+      activity !== currentExecution.current
     ) {
+      currentExecution.setCurrentActivity(activity);
+
+      // If the previous activity was SIT, set the execution as started
+      if (currentExecution.previous === Activity.SIT) {
+        currentExecution.status = Status.STARTED
+      }
+    }
+
+    // If the execution has started, the last three estimations are the same activity
+    // and that activity is SIT, then finish the execution
+    if (
+      currentExecution.status === Status.STARTED &&
+      areRecognitionsEqualAndSignificant(lastThree) &&
+      activity === Activity.SIT
+    ) {
+      currentExecution.status = Status.FINISHED;
       return {
         eventName: TEST_ENDING_EVENT
       }
@@ -54,13 +65,22 @@ export class RecognitionResultEvaluationTask extends Task {
       eventName: DEFAULT_EVENT
     }
   }
+}
 
-  private areEqual(array: string[]): boolean {
-    return array.every((val, i, arr) => val === arr[0]);
-  }
+function areRecognitionsEqualAndSignificant(recognitions: RecognitionResult[]): boolean {
+  return areRecognitionsEqual(recognitions) && areRecognitionsSignificant(recognitions);
+}
 
-  private areDifferent(a: string, b: string): boolean {
-    return a !== b;
-  }
+function areRecognitionsEqual(recognitions: RecognitionResult[]): boolean {
+  return recognitions
+    .map((recognition) => fromString(recognition.inference.class))
+    .every((recognition, i, recognitions) => recognition === recognitions[0]);
+}
 
+function areRecognitionsSignificant(recognitions: RecognitionResult[]): boolean {
+  const meanProbabilities = recognitions
+    .map((recognition) => recognition.inference.probability)
+    .reduce((prev, curr) => prev + curr) / recognitions.length;
+
+  return meanProbabilities > SIGNIFICANCE_THRESHOLD;
 }

--- a/app/core/tasks/tug/recognition-result-evaluation.ts
+++ b/app/core/tasks/tug/recognition-result-evaluation.ts
@@ -40,10 +40,11 @@ export class RecognitionResultEvaluationTask extends Task {
       areRecognitionsEqualAndSignificant(lastThree) &&
       activity !== currentExecution.current
     ) {
-      currentExecution.setCurrentActivity(activity);
+      const previous = currentExecution.current;
+      currentExecution.current = activity;
 
       // If the previous activity was SIT, set the execution as started
-      if (currentExecution.previous === Activity.SIT) {
+      if (previous === Activity.SIT) {
         currentExecution.status = Status.STARTED
       }
     }

--- a/app/core/tug-test/execution.ts
+++ b/app/core/tug-test/execution.ts
@@ -20,14 +20,12 @@ export class TugExecution {
     return this._recognitionResults;
   }
 
-  private _previous: Activity;
-  get previous(): Activity {
-    return this._previous;
-  }
-
   private _current: Activity;
   get current(): Activity {
     return this._current;
+  }
+  set current(value) {
+    this._current = value;
   }
 
   private _status: Status;
@@ -48,11 +46,6 @@ export class TugExecution {
 
   addNew(recognitionResult: RecognitionResult) {
     this._recognitionResults.push(recognitionResult);
-  }
-
-  setCurrentActivity(activity: Activity) {
-    this._previous = this.current;
-    this._current = activity;
   }
 
   computeResults(): TugResult {

--- a/app/core/tug-test/execution.ts
+++ b/app/core/tug-test/execution.ts
@@ -43,7 +43,7 @@ export class TugExecution {
     private starTime = Date.now()
   ) {
     this._current = Activity.SIT;
-    this._status = Status.FIRST_PHASE;
+    this._status = Status.YET_TO_START;
   }
 
   addNew(recognitionResult: RecognitionResult) {
@@ -53,10 +53,6 @@ export class TugExecution {
   setCurrentActivity(activity: Activity) {
     this._previous = this.current;
     this._current = activity;
-  }
-
-  checkPreviousCurrentSequence(previous: Activity, current: Activity): boolean {
-    return this.previous === previous && this.current === current;
   }
 
   computeResults(): TugResult {
@@ -150,7 +146,7 @@ export class TugExecution {
 }
 
 export enum Status {
-  FIRST_PHASE,
-  SECOND_PHASE,
+  YET_TO_START,
+  STARTED,
   FINISHED,
 }

--- a/app/core/tug-test/manager.ts
+++ b/app/core/tug-test/manager.ts
@@ -1,4 +1,4 @@
-import { Status, TugExecution } from "~/core/tug-test/execution";
+import { TugExecution } from "~/core/tug-test/execution";
 import { TugResult } from "~/core/tug-test/result";
 
 export class TugManager {
@@ -17,14 +17,11 @@ export class TugManager {
     if (this.ongoing)
       throw new Error("Could not create a TUG execution. Already ongoing!");
 
-    console.log("[TUG MANAGER]: tug execution created!");
     this._currentExecution = new TugExecution(sourceDevice);
   }
 
   endExecution(): TugResult {
     const execution = this.currentExecution;
-    execution.status = Status.FINISHED;
-
     this._currentExecution = undefined;
 
     return execution.computeResults();


### PR DESCRIPTION
This PR includes changes to the algorithm responsible of the automatic detection of the TUG execution, simplifying and improving it.

In the previous version, the algorithm tried to identify the first turn action to determine the phase where the user was. When this algorithm was not able to correctly determine the phase change, the automatic end detection failed.

Now, the algorithm has been simplified in the following way:
- It tries to determine when the user has started the test (i.e., stand up).
- It tries to determine when the user has sat down after the test was started. In this way, the test will be always automatically ended when the user sits down.